### PR TITLE
Simpler and faster - do not produce duplicate anagrams

### DIFF
--- a/test/models/anagrams_test.ex
+++ b/test/models/anagrams_test.ex
@@ -14,7 +14,7 @@ defmodule Wordular.AnagramsTest do
 
   test "can handle duplicate words in the input phrase" do
     result = Anagrams.for("apple racecar apple", ["race", "car", "apple", "racecar"])
-    assert result == ["apple apple racecar", "apple apple car race"]
+    assert result == ["apple apple car race", "apple apple racecar"]
   end
 
   @tag timeout: 60000, big: true, slow: true

--- a/timings.txt
+++ b/timings.txt
@@ -1,0 +1,3 @@
+5.16 vs 4.7
+add "lad" - 15.81  vs 12.01
+add "o lad" - vs 50.56

--- a/web/models/anagrams.ex
+++ b/web/models/anagrams.ex
@@ -63,14 +63,18 @@ defmodule Anagrams do
     usable_entries = usable_entries_for(dict_entries, phrase)
 
     answers = Enum.reduce(usable_entries, %{dict: usable_entries, anagrams: []}, fn(entry, acc) ->
-      anagrams_without_this_entry = anagrams_for(
+      anagrams_without_entry = anagrams_for(
       (phrase |> without(entry)), acc.dict
       )
-      anagrams_with_this_entry = Enum.map(anagrams_without_this_entry, fn (smaller_anagram) ->
-        [entry | smaller_anagram]
-      end)
-      # TODO - prepend instead of concatenating
-      %{dict: tl(acc.dict), anagrams: acc[:anagrams] ++ anagrams_with_this_entry}
+
+      updated_anagrams = Enum.reduce(
+      anagrams_without_entry, acc[:anagrams], fn (anagram_without_entry, acc) ->
+        anagram_with_entry = [entry | anagram_without_entry]
+        [anagram_with_entry | acc]
+      end
+      )
+
+      %{dict: tl(acc.dict), anagrams: updated_anagrams}
     end)
 
     answers[:anagrams]
@@ -91,7 +95,6 @@ defmodule Anagrams do
   def cartesian_product([]), do: []
   def cartesian_product(lists) do
     Enum.reduce(lists, [ [] ], fn one_list, acc ->
-      # New acc is: everything we've built so far, with every new option prepended
       for item <- one_list, subproduct <- acc, do: [item | subproduct]
     end)
   end


### PR DESCRIPTION
Previously, we produced a lot of duplicate anagrams, but compensated in
a couple of ways. First, we removed them by using mapsets, so that they
didn't show up in the final results. Second, we used an agent so that if
we were trying to produce anagrams for a phrase we'd already done, we
didn't have to do all the work again.

However, Jared pointed out the first issue, and it made the second clear
as another compromise. The real problem was that we were producing the
duplicates at all.

This happened as follows: say we had the phrase "abc" and the dictionary
["a", "b", "c"].  First, we'd take "a" and find all the anagrams of
"abc" we could build with it and other dictionary entries. That would
include the phrase "a b c". At this point, we'd have every possible answer
that used "a". Having finished a round of iteration with "a", we'd
proceed to "b". What can we build with "b" and the dictionary ["a",
"b", "c"]? Since we've left "a" in the dictionary, we'll build "a b c"
again. But here's the key: _we don't need "a" in the dictionary anymore_.
We've already built every possible anagram that includes "a".

Instead, we throw it out. We switch from a list comprehension to an
Enum.reduce, and part of the state we carry along to the next iteration
is what our current dictionary is. When we start looking for anagrams
that include "b", we use a dictionary that doesn't have "a" in it. Each
new iteration has a smaller dictionary. This avoids building all the
duplicates in the first place, so MapSets aren't needed anymore.

The Agent also isn't needed anymore for caching, since we never try to
find anagrams for the same phrase twice.

Big speedup!

...Ok, "how big is the speedup, Nathan?" is what you're wondering. The
answer is that I was too lazy to properly measure. I got ~6s on the
"slow" test case, vs ~15s on master. If I change that test case to have
a longer phrase, both versions are still too slow to finish before
ExUnit kills them, and ain't nobody got time to wait upwards of 2
minutes to compare.
